### PR TITLE
Create separate task for processing status messages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+"python.analysis.typeCheckingMode": "basic",
+"autopep8.args": [
+    "--max-line-length",
+    "120",
+    "--experimental"
+]
+}

--- a/src/airtouch2/protocol/at2plus/message_common.py
+++ b/src/airtouch2/protocol/at2plus/message_common.py
@@ -69,10 +69,10 @@ class Header(Serializable):
         address = Address(header_bytes[CommonMessageOffsets.ADDRESS+1])
         if type == MessageType.CONTROL_STATUS:
             if (address != Address.NORMAL):
-                raise ValueError("Message address value is invalid: ", header_bytes.hex(":"))
+                raise ValueError(f"Message address value is invalid: {header_bytes.hex(':')}")
         elif type == MessageType.EXTENDED:
             if (address != Address.EXTENDED):
-                raise ValueError("Message address value is invalid: ", header_bytes.hex(":"))
+                raise ValueError(f"Message address value is invalid: {header_bytes.hex(':')}")
         else:
             raise ValueError("Message type is invalid")
         id = header_bytes[CommonMessageOffsets.MESAGE_ID]

--- a/test_programs/at2plus_test.py
+++ b/test_programs/at2plus_test.py
@@ -5,15 +5,18 @@ import logging
 import asyncio
 import aioconsole
 
-logging.basicConfig(filename='airtouch2plus.log',filemode='a', level=logging.DEBUG, format='%(asctime)s %(threadName)s %(levelname)s: %(message)s')
+logging.basicConfig(filename='airtouch2plus.log', filemode='a', level=logging.DEBUG,
+                    format='%(asctime)s %(threadName)s %(levelname)s: %(message)s')
 _LOGGER = logging.getLogger()
 _LOGGER.addHandler(logging.StreamHandler())
 logging.getLogger('asyncio').setLevel(logging.WARNING)
+
 
 class AcStatusLogger:
     client: At2PlusClient
     acs: list[At2PlusAircon]
     cleanup_callbacks: list[Callable]
+
     def __init__(self, client: At2PlusClient):
         self.cleanup_callbacks = []
         self.acs = []
@@ -25,11 +28,12 @@ class AcStatusLogger:
                 self.acs.append(ac)
                 _LOGGER.info(ac.status)
                 _LOGGER.info(ac.ability)
-                self.cleanup_callbacks.append(ac.add_callback(lambda : _LOGGER.info(ac.status)))
+                self.cleanup_callbacks.append(ac.add_callback(lambda: _LOGGER.info(ac.status)))
 
     def cleanup(self):
         while len(self.cleanup_callbacks) > 0:
             self.cleanup_callbacks.pop()()
+
 
 async def main():
     addr = await aioconsole.ainput("Enter airtouch2plus IP address: ")


### PR DESCRIPTION
Also:
* Specify autopep8 parameter for wrapping lines at 120 chars
* Use f-strings
* force type checking

Can you please use the newer 'f-strings' when printing variables.
Also I decided to force increase the length of line wrapping because it was annoying me being so short.

This should hopefully fix the hanging issue. My idea for the architecture was to have a main loop (`_main`) that just reads all the incoming messages, but to start new tasks that actually do the processing of each one, once its read. The task that processes status messages can send an AcAbility request, but of course the main loop then needs to actually run to process the response and put it in the queue. It wasn't doing this before, it was blocked by the `await _handle_status_message()`, so we ended up in a deadlock.